### PR TITLE
update ejs & ignore package-lock.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ jspm_packages
 # Yarn Integrity file
 .yarn-integrity
 
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "body-parser": "~1.15.1",
     "cookie-parser": "~1.4.3",
     "debug": "~2.2.0",
-    "ejs": "~2.4.1",
+    "ejs": ">=2.5.5",
     "express": "~4.13.4",
     "express-session": "^1.14.2",
     "md5": "^2.2.1",


### PR DESCRIPTION
The ejs dependency defined in package.json has a known moderate severity security vulnerability in version range < 2.5.5 and should be updated.